### PR TITLE
feat(blocks): logos

### DIFF
--- a/web/app/themes/adeliom/app/Block/Content/LogoBlock.php
+++ b/web/app/themes/adeliom/app/Block/Content/LogoBlock.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Block\Content;
+
+use Adeliom\Lumberjack\Admin\AbstractBlock;
+use Adeliom\Lumberjack\Admin\Fields\Layout\LayoutField;
+use Adeliom\Lumberjack\Admin\Fields\Medias\ImageField;
+use Adeliom\Lumberjack\Admin\Fields\Tabs\ContentTab;
+use Adeliom\Lumberjack\Admin\Fields\Tabs\LayoutTab;
+use Adeliom\Lumberjack\Admin\Fields\Typography\HeadingField;
+use Adeliom\Lumberjack\Admin\Fields\Typography\TextField;
+use App\Enum\BlocksTwigPath;
+use App\Enum\GutBlockName;
+use Extended\ACF\Fields\Repeater;
+
+/**
+ * Class LogoBlock
+ * @see https://github.com/wordplate/extended-acf#fields
+ * @package App\FlexibleLayout
+ */
+class LogoBlock extends AbstractBlock
+{
+    public const NAME = "logo";
+    public const TITLE = "Liste de logos";
+    public const DESCRIPTION = "Bloc comprenant une liste de logos (entreprises, partenaires...)";
+
+    public function __construct()
+    {
+        parent::__construct([
+            'mode' => 'edit',
+            'category' => GutBlockName::CONTENT,
+            'dir' => BlocksTwigPath::CONTENT
+        ]);
+    }
+
+    public static function getFields(): ?\Traversable
+    {
+        yield from ContentTab::make()->fields([
+            HeadingField::make()->tag(),
+            Repeater::make("Éléments", "items")
+                ->fields([
+                    TextField::make('Titre', 'title'),
+                    ImageField::make('Logo')->required(),
+                ])
+                ->layout("block")
+                ->min(1)
+        ]);
+
+        yield from LayoutTab::make()->fields([
+            LayoutField::margin()
+        ]);
+    }
+}

--- a/web/app/themes/adeliom/views/blocks/content/logo.html.twig
+++ b/web/app/themes/adeliom/views/blocks/content/logo.html.twig
@@ -1,0 +1,29 @@
+{% embed "blocks/block.html.twig" %}
+    {% block content %}
+        {% import "components/typography/typography.html.twig" as typography %}
+
+        <div class="grid gap-6 lg:grid-cols-12 lg:gap-10">
+            {{ typography.heading({
+                content: fields.title,
+                className: 'text-center col-span-full lg:col-start-3 lg:col-end-11',
+            }) }}
+
+            <div class="col-span-full flex flex-wrap justify-center gap-y-6 md:gap-10">
+                {% for item in fields.items %}
+                    <div class="flex flex-col items-center gap-4 w-1/2 max-sm:max-w-[160px] sm:w-40 lg:w-48">
+                        <div class="relative overflow-hidden w-full aspect-[100/40]">
+                            {% include "components/content/media/image.html.twig" with {
+                                media: item.image,
+                                className: "contain-full object-center p-4",
+                            } %}
+                        </div>
+                        {{ typography.text({
+                            content: item.title,
+                            className: 'text-center',
+                        }) }}
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    {% endblock %}
+{% endembed %}


### PR DESCRIPTION
# Résumé

Ajout d'un block Gutenberg permettant de mettre en avant une succession de logos. Chaque logo peut-être accompagné d'un texte.