### PR TITLE
fix(#73): block categories were not working

### DIFF
--- a/web/app/themes/adeliom/app/Enum/GutBlockName.php
+++ b/web/app/themes/adeliom/app/Enum/GutBlockName.php
@@ -11,4 +11,10 @@ final class GutBlockName
 
     public const NAVIGATION = 'navigation';
     public const RELATION = 'relation';
+    public const GENERIC = 'generic';
+    public const LATEST = 'latest';
+    public const OTHERS = 'others';
+    public const DOWNLOAD = 'download';
+    public const ACCORDIONS = 'accordions';
+    public const TESTIMONIALS = 'testimonials';
 }

--- a/web/app/themes/adeliom/app/Hooks/Admin/BlockHooks.php
+++ b/web/app/themes/adeliom/app/Hooks/Admin/BlockHooks.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Hooks\Admin;
+
+use Adeliom\Lumberjack\Hooks\Models\Filter;
+use App\Enum\GutBlockName;
+
+class BlockHooks
+{
+    /**
+     * Ajout d'un nouveau type de catégorie dans les blocs GUT
+     */
+    #[Filter(tag: 'block_categories_all', priority: 10, accepted_args: 2)]
+    public static function blockCategory($categories, $post)
+    {
+        return array_merge(
+            $categories,
+            [
+                [
+                    'slug' => GutBlockName::GENERIC,
+                    'title' => 'Texte et Images',
+                    'icon' => 'align-right',
+                ],
+                [
+                    'slug' => GutBlockName::LISTING,
+                    'title' => 'Listes',
+                    'icon' => 'editor-ul',
+                ],
+                [
+                    'slug' => GutBlockName::CTA,
+                    'title' => 'CTA',
+                    'icon' => 'button',
+                ],
+                [
+                    'slug' => GutBlockName::DOWNLOAD,
+                    'title' => 'Téléchargement',
+                    'icon' => 'download',
+                ],
+                [
+                    'slug' => GutBlockName::ACCORDIONS,
+                    'title' => 'Accordéons',
+                    'icon' => 'arrow-down-alt2',
+                ],
+                [
+                    'slug' => GutBlockName::TESTIMONIALS,
+                    'title' => 'Témoignages',
+                    'icon' => 'format-quote',
+                ],
+                [
+                    'slug' => GutBlockName::LATEST,
+                    'title' => 'Remontées automatiques',
+                    'icon' => 'page',
+                ],
+                [
+                    'slug' => GutBlockName::OTHERS,
+                    'title' => 'Autre',
+                    'icon' => 'marker',
+                ],
+                [
+                    'slug' => GutBlockName::NAVIGATION,
+                    'title' => 'Navigation',
+                    'icon' => 'menu',
+                ],
+                [
+                    'slug' => GutBlockName::RELATION,
+                    'title' => 'Relation',
+                    'icon' => 'networking',
+                ],
+                [
+                    'slug' => GutBlockName::HERO,
+                    'title' => 'Header',
+                    'icon' => 'editor-kitchensink',
+                ],
+                [
+                    'slug' => GutBlockName::CONTENT,
+                    'title' => 'Contenu',
+                    'icon' => 'admin-post',
+                ]
+            ]
+        );
+    }
+}

--- a/web/app/themes/adeliom/app/Hooks/Admin/ConfigHooks.php
+++ b/web/app/themes/adeliom/app/Hooks/Admin/ConfigHooks.php
@@ -15,9 +15,6 @@ use App\Admin\ParametersAdmin;
  */
 class ConfigHooks
 {
-    /**
-     * @Action("acf/init")
-     */
     #[Action("acf/init")]
     public static function googleApiKey(): void
     {
@@ -30,8 +27,6 @@ class ConfigHooks
 
     /**
      * Set pretty permalinks
-     *
-     * @Action("after_switch_theme")¨
      */
     #[Action("after_switch_theme")]
     public static function prettyPermalinks(): void
@@ -41,9 +36,6 @@ class ConfigHooks
         flush_rewrite_rules();
     }
 
-    /**
-     * @Action("map_meta_cap", 10, 4)
-     */
     #[Action("map_meta_cap", 10, 4)]
     public static function customManagePrivacyOptions($caps, $cap, $user_id, $args)
     {
@@ -55,19 +47,12 @@ class ConfigHooks
         return $caps;
     }
 
-    /**
-     * @Filter("redirection_role")
-     */
     #[Filter("redirection_role")]
     public static function accessRedirectionEditor(): string
     {
         return 'edit_pages';
     }
 
-    /**
-     * Ajout menu dans la sidebar pour les éditeurs
-     * @Action("admin_menu")
-     */
     #[Action("admin_menu")]
     public static function changeMenuPosition(): void
     {

--- a/web/app/themes/adeliom/app/Hooks/Admin/ThemeHooks.php
+++ b/web/app/themes/adeliom/app/Hooks/Admin/ThemeHooks.php
@@ -15,9 +15,6 @@ use Adeliom\Lumberjack\Hooks\Models\Filter;
  */
 class ThemeHooks
 {
-    /**
-     * @Filter("timber_context")
-     */
     #[Filter("timber_context")]
     public static function globalContext($context)
     {
@@ -30,8 +27,6 @@ class ThemeHooks
     }
     /**
      * Ajout des scripts de base
-     *
-     * @Action("wp_enqueue_scripts")
      */
     #[Action("wp_enqueue_scripts")]
     public static function enqueueScripts(): void
@@ -42,7 +37,6 @@ class ThemeHooks
 
     /**
      * Ajouter une feuille de style pour l’éditeur dans l’admin
-     * @Action(tag="enqueue_block_editor_assets")
      */
     #[Action("enqueue_block_editor_assets")]
     public static function editorStyle(): void
@@ -52,8 +46,6 @@ class ThemeHooks
 
     /**
      * Remove comment from admin menu
-     *
-     * @Action("admin_menu", 15)
      */
     #[Action("admin_menu", 15)]
     public static function removeCommentFromMenu(): void
@@ -68,8 +60,6 @@ class ThemeHooks
 
     /**
      * Remove manage options from post (options in topbar)
-     *
-     * @Action("screen_options_show_screen")
      */
     #[Action("screen_options_show_screen")]
     public static function removeManageOptions(): bool
@@ -79,8 +69,6 @@ class ThemeHooks
 
     /**
      * Remove all notices
-     *
-     * @Action("init", 100)
      */
     #[Action("init", 100)]
     public static function removeAllNotices(): void
@@ -90,10 +78,6 @@ class ThemeHooks
         }
     }
 
-    /**
-     * @Action("admin_enqueue_scripts")
-     * @Action("login_enqueue_scripts")
-     */
     #[Action("login_enqueue_scripts")]
     #[Action("admin_enqueue_scripts")]
     public static function themeStyle(): void
@@ -110,8 +94,6 @@ class ThemeHooks
 
     /**
      * Supprimer l’entrée “Personnaliser” dans la top bar (FO)
-     *
-     * @Action("wp_before_admin_bar_render")
      */
     #[Action("wp_before_admin_bar_render")]
     public static function beforeAdminMenuRender(): void
@@ -124,8 +106,6 @@ class ThemeHooks
 
     /**
      * Supprimer les entrées pour créer un nouveau média ou un nouvel article (quand on les désactives) depuis la top bar (FO)
-     *
-     * @Action("admin_bar_menu", 999)
      */
     #[Action("admin_bar_menu", 999)]
     public static function removeEntriesFromAdminBar(): void

--- a/web/app/themes/adeliom/app/Hooks/Admin/WysiwygHooks.php
+++ b/web/app/themes/adeliom/app/Hooks/Admin/WysiwygHooks.php
@@ -20,8 +20,6 @@ class WysiwygHooks
 
     /**
      * Change title page into custom placeholder
-     *
-     * @Filter("enter_title_here")
      */
     #[Filter("enter_title_here")]
     public static function customPlaceholder(string $title = ""): string
@@ -33,10 +31,6 @@ class WysiwygHooks
         return $title;
     }
 
-    /**
-     * @Filter(tag="mce_css")
-     * @return string
-     */
     #[Filter("mce_css")]
     public static function customCss($mce_css): string
     {
@@ -47,11 +41,6 @@ class WysiwygHooks
         return $mce_css;
     }
 
-    /**
-     * @Filter(tag="tiny_mce_before_init")
-     * @param $settings
-     * @return array
-     */
     #[Filter("tiny_mce_before_init")]
     public static function customStyleFormats($settings): array
     {
@@ -108,12 +97,6 @@ class WysiwygHooks
         return $settings;
     }
 
-    /**
-     * @Filter("acf/fields/wysiwyg/toolbars")
-     *
-     * @param array $toolbars
-     * @return array
-     */
     #[Filter("acf/fields/wysiwyg/toolbars")]
     public static function wysiwygToolbars(array $toolbars): array
     {
@@ -149,8 +132,6 @@ class WysiwygHooks
 
     /**
      * Clean tinyMCE
-     *
-     * @Filter("mce_buttons")
      */
     #[Filter("mce_buttons")]
     public static function removeButtons($buttons): array
@@ -182,8 +163,6 @@ class WysiwygHooks
 
     /**
      * Clean tinyMCE 2nd row
-     *
-     * @Filter("mce_buttons_2")
      */
     #[Filter("mce_buttons_2")]
     public static function removeButtonLine2($buttons): array
@@ -220,8 +199,6 @@ class WysiwygHooks
 
     /**
      * Remove heading useless
-     *
-     * @Filter("tiny_mce_before_init")
      */
     #[Filter("tiny_mce_before_init")]
     public static function removeHeadings($headings): array

--- a/web/app/themes/adeliom/config/hooks.php
+++ b/web/app/themes/adeliom/config/hooks.php
@@ -10,5 +10,6 @@ return [
         App\Hooks\Admin\ConfigHooks::class,
         App\Hooks\Admin\ThemeHooks::class,
         App\Hooks\Admin\WysiwygHooks::class,
+        App\Hooks\Admin\BlockHooks::class,
     ],
 ];


### PR DESCRIPTION
# Résumé

* Restauration de la fonction de catégorisation des blocks Gutenberg
* Suppression des appels aux hooks via les anciennes annotations (< PHP 8)
